### PR TITLE
spelling fixes

### DIFF
--- a/messagetypes.go
+++ b/messagetypes.go
@@ -62,7 +62,7 @@ type msgFlags struct {
 	GroupMessage                   bool
 }
 
-// NewMsgID returns a randomly genrated message ID (not cryptographically secure!)
+// NewMsgID returns a randomly generated message ID (not cryptographically secure!)
 // TODO: Why mrand?
 func NewMsgID() uint64 {
 	mrand.Seed(int64(time.Now().Nanosecond()))
@@ -70,7 +70,7 @@ func NewMsgID() uint64 {
 	return msgID
 }
 
-// NewGrpID returns a randomly genrated group ID (not cryptographically secure!)
+// NewGrpID returns a randomly generated group ID (not cryptographically secure!)
 // TODO: Why mrand?
 func NewGrpID() [8]byte {
 	mrand.Seed(int64(time.Now().Nanosecond()))

--- a/packetdispatcher.go
+++ b/packetdispatcher.go
@@ -20,9 +20,9 @@ import (
 
 func dispatcherPanicHandler(context string, i interface{}) error {
 	if _, ok := i.(string); ok {
-		return fmt.Errorf("%s: error occured dispatching %s", context, i)
+		return fmt.Errorf("%s: error occurred dispatching %s", context, i)
 	}
-	return fmt.Errorf("%s: unknown dispatch error occured: %#v", context, i)
+	return fmt.Errorf("%s: unknown dispatch error occurred: %#v", context, i)
 }
 
 func writeHelper(wr io.Writer, buf *bytes.Buffer) {

--- a/packetserializer.go
+++ b/packetserializer.go
@@ -214,9 +214,9 @@ func serializeTypingNotification(tn TypingNotificationMessage) *bytes.Buffer {
 
 func serializerPanicHandler(context string, i interface{}) error {
 	if _, ok := i.(string); ok {
-		return fmt.Errorf("%s: error occured serializing %s", context, i)
+		return fmt.Errorf("%s: error occurred serializing %s", context, i)
 	}
-	return fmt.Errorf("%s: unknown serializing error occured: %#v", context, i)
+	return fmt.Errorf("%s: unknown serializing error occurred: %#v", context, i)
 }
 
 func serializeHelper(buf *bytes.Buffer, i interface{}) *bytes.Buffer {

--- a/rest.go
+++ b/rest.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-// ThreemaRest provides convinient wrappers for task that require the use of Threemas REST API
+// ThreemaRest provides convenient wrappers for task that require the use of Threemas REST API
 type ThreemaRest struct {
 	client apiclient_pkg.APICLIENT_IMPL
 }
@@ -27,7 +27,7 @@ func (tr ThreemaRest) CreateIdentity() (ThreemaID, error) {
 
 	pubkey := base64.StdEncoding.EncodeToString(publicKey[:])
 
-	// The nonce is harcoded in threema
+	// The nonce is hardcoded in threema
 	nonce := [24]byte{0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x20, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e}
 
 	// Request token and tokenRespKeyPub
@@ -88,7 +88,7 @@ func (tr ThreemaRest) CreateIdentity() (ThreemaID, error) {
 func (tr ThreemaRest) setFeatureLevel(thid ThreemaID, featurelevel int) (succes bool) {
 	featureLevelFloat := float64(featurelevel)
 
-	// The nonce is harcoded in threema
+	// The nonce is hardcoded in threema
 	nonce := [24]byte{0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x20, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e}
 	nonceB64 := base64.StdEncoding.EncodeToString(nonce[:])
 


### PR DESCRIPTION
patch contains some spelling-fixes, as found by a bot. ( https://github.com/ka7/misspell_fixer )
should affect only text, /*comments*/ and other, non-critical stuff.