### PR TITLE
spelling fixes, might break stuff

### DIFF
--- a/packettypes.go
+++ b/packettypes.go
@@ -9,14 +9,14 @@ const (
 	SENDINGMSG pktType = 0x1
 	// DELIVERINGMSG is the packet type of a message packet from server to client
 	DELIVERINGMSG pktType = 0x2
-	// SERVERACK is the packet type of a server ack for a messsage sent by the client
+	// SERVERACK is the packet type of a server ack for a message sent by the client
 	SERVERACK pktType = 0x81
-	// CLIENTACK is the packet type of a client ack for a messsage delivered by the server
+	// CLIENTACK is the packet type of a client ack for a message delivered by the server
 	CLIENTACK pktType = 0x82
 	// CONNESTABLISHED is the packet type of a pkt send by ther server when all MSGs have been delivered
 	CONNESTABLISHED pktType = 0xd0
-	// MSGHEADERLENGHT is the length of a ThreemaMessageHeader
-	MSGHEADERLENGHT uint8 = 64
+	// MSGHEADERLENGTH is the length of a ThreemaMessageHeader
+	MSGHEADERLENGTH uint8 = 64
 )
 
 // ThreemaMessageHeader contains fields that every type of message needs


### PR DESCRIPTION
patch contains some spelling-fixes, as found by a bot. ( https://github.com/ka7/misspell_fixer )
... this one might break stuff, as it touches one constant
 -	MSGHEADERLENGHT uint8 = 64
+	MSGHEADERLENGTH uint8 = 64
