### PR TITLE
Add go-report-card badge/link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/o3ma/o3)](https://goreportcard.com/report/o3ma/o3)
 # o3
 
 Re-implementation of the [Threema](https://threema.ch) protocol. GoDoc [here](https://godoc.org/github.com/o3ma/o3), better documentation will follow.


### PR DESCRIPTION
This PR adds a badge + link to https://goreportcard.com/report/github.com/o3ma/o3 to the Readme.

'goreportcard' computes and displays various infos/stats for a go project, such as formatting errors, linter warnings, cyclomatic complexity values, etc.