### PR TITLE
Updated to latest API version - added LicenceKey parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 # o3
 
 Re-implementation of the [Threema](https://threema.ch) protocol. GoDoc [here](https://godoc.org/github.com/o3ma/o3), better documentation will follow.
+
+Requires a threema license from: https://shop.threema.ch/ (only for new
+identities)

--- a/communicationhandler.go
+++ b/communicationhandler.go
@@ -177,18 +177,18 @@ func (sc *SessionContext) sendLoop() {
 
 // SendTextMessage sends a Text Message to the specified ID
 // Enqueued messages will be received, not acknowledged and discarded
-func (sc *SessionContext) SendTextMessage(recipient string, text string, sendMsgChan chan<- Message) error {
+func (sc *SessionContext) SendTextMessage(recipient string, text string, sendMsgChan chan<- Message) (uint64, error) {
 	// build a message
 	tm, err := NewTextMessage(sc, recipient, text)
 
 	// TODO: error handling
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	sendMsgChan <- tm
 
-	return nil
+	return tm.ID(), nil
 }
 
 // SendImageMessage sends a Image Message to the specified ID
@@ -223,17 +223,17 @@ func (sc *SessionContext) SendAudioMessage(recipient string, filename string, se
 }
 
 // SendGroupTextMessage Sends a text message to all members
-func (sc *SessionContext) SendGroupTextMessage(group Group, text string, sendMsgChan chan<- Message) (err error) {
+func (sc *SessionContext) SendGroupTextMessage(group Group, text string, sendMsgChan chan<- Message) (tms []GroupTextMessage, err error) {
 
-	tms, err := NewGroupTextMessages(sc, group, text)
+	tms, err = NewGroupTextMessages(sc, group, text)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, msg := range tms {
 		sendMsgChan <- msg
 	}
 
-	return nil
+	return tms, nil
 }
 
 // CreateNewGroup Creates a new group and notifies all members

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/o3ma/o3

--- a/identity.go
+++ b/identity.go
@@ -174,11 +174,17 @@ func ParseIDBackupString(idstr string, password []byte) (ThreemaID, error) {
 // will always look different even if using the same password and ID because the salt is re-generated
 // with each backup.
 func (thid ThreemaID) SaveToFile(filename string, password []byte) error {
-	idstr, err := encryptID(thid.ID[:], thid.LSK[:], password)
+	idstr, err := thid.CreateIDBackupString(password)
 	if err != nil {
 		return err
 	}
 	return ioutil.WriteFile(filename, []byte(idstr+"\n"), 0600)
+}
+
+// CreateIDBackupString encodes the base32-encoded encrypted ID string contained to a threema backup.
+func (thid ThreemaID) CreateIDBackupString(password []byte) (string, error) {
+	idstr, err := encryptID(thid.ID[:], thid.LSK[:], password)
+	return idstr, err
 }
 
 // NewThreemaID creates a ThreemaID from a given id strnig and a 256-bit private key

--- a/messagetypes.go
+++ b/messagetypes.go
@@ -16,6 +16,7 @@ type MsgType uint8
 // MsgType mock enum
 const (
 	TEXTMESSAGE             MsgType = 0x1  //indicates a text message
+	UNKNOWN_TYPE_1          MsgType = 0x1A //indicates a text message
 	IMAGEMESSAGE            MsgType = 0x2  //indicates a image message
 	AUDIOMESSAGE            MsgType = 0x14 //indicates a audio message
 	POLLMESSAGE             MsgType = 0x15 //indicates a poll message

--- a/messagetypes.go
+++ b/messagetypes.go
@@ -15,14 +15,16 @@ type MsgType uint8
 
 // MsgType mock enum
 const (
-	TEXTMESSAGE             MsgType = 0x1  //indicates a text message
-	UNKNOWN_TYPE_1          MsgType = 0x1A //indicates a text message
-	IMAGEMESSAGE            MsgType = 0x2  //indicates a image message
+	TEXTMESSAGE             MsgType = 0x01 //indicates a text message
+	IMAGEMESSAGE            MsgType = 0x02 //indicates a image message
+	LOCATIONMESSAGE         MsgType = 0x10 //indicates a location message
 	AUDIOMESSAGE            MsgType = 0x14 //indicates a audio message
-	POLLMESSAGE             MsgType = 0x15 //indicates a poll message
-	LOCATIONMESSAGE         MsgType = 0x16 //indicates a location message
+	POLL_CREATE_MESSAGE     MsgType = 0x15 //indicates a poll message
+	POLL_VOTE_MESSAGE       MsgType = 0x16 //indicates a poll message
 	FILEMESSAGE             MsgType = 0x17 //indicates a file message
+	CONTACT_REQ_PHOTO       MsgType = 0x1A //indicates a text message
 	GROUPTEXTMESSAGE        MsgType = 0x41 //indicates a group text message
+	GROUPLOCATIONMESSAGE    MsgType = 0x42 //indicates a group image message
 	GROUPIMAGEMESSAGE       MsgType = 0x43 //indicates a group image message
 	GROUPSETMEMEBERSMESSAGE MsgType = 0x4A //indicates a set group member message
 	GROUPSETNAMEMESSAGE     MsgType = 0x4B //indicates a set group name message

--- a/packethandler.go
+++ b/packethandler.go
@@ -150,6 +150,10 @@ func (sc *SessionContext) handleMessagePacket(mp messagePacket) (Message, error)
 		message = AudioMessage{
 			messageHeader:    newMsgHdrFromPkt(mp),
 			audioMessageBody: parseAudioMessage(buf)}
+	case CONTACT_REQ_PHOTO:
+		message = TextMessage{
+			messageHeader:   newMsgHdrFromPkt(mp),
+			textMessageBody: parseTextMessage(buf)}
 	case GROUPTEXTMESSAGE:
 		message = GroupTextMessage{
 			groupMessageHeader: parseGroupMessageHeader(buf),

--- a/rest.go
+++ b/rest.go
@@ -17,7 +17,7 @@ type ThreemaRest struct {
 }
 
 // CreateIdentity generates a new NaCl Keypair, registers it with the Three servers and returns the assigned ID
-func (tr ThreemaRest) CreateIdentity() (ThreemaID, error) {
+func (tr ThreemaRest) CreateIdentity(deviceUUID string, licenseKey string) (ThreemaID, error) {
 	// Get Keypair and nonce ready
 	publicKey, privateKey, err := box.GenerateKey(rand.Reader)
 	if err != nil {
@@ -55,9 +55,11 @@ func (tr ThreemaRest) CreateIdentity() (ThreemaID, error) {
 	tokenResponse := base64.StdEncoding.EncodeToString(box.Seal(nil, []byte(token), &nonce, &tokenPubKey, privateKey))
 
 	response := models_pkg.CreateStage2Request{
-		PublicKey: &pubkey,
-		Response:  &tokenResponse,
-		Token:     challenge.Token}
+		PublicKey:  &pubkey,
+		Response:   &tokenResponse,
+		Token:      challenge.Token,
+        DeviceId:   &deviceUUID,
+        LicenseKey: &licenseKey}
 
 	finalResult, err := tr.client.IdentityCreateStage2(&response)
 	if err != nil {


### PR DESCRIPTION
As the current version of the API is not supported the creation of a NEW identity is not possible anymore. The following error is the result: https://github.com/o3ma/o3rest/issues/2

Using the updated API and a license from the theema store (shop.threema.ch) it works again.

Also see: https://github.com/o3ma/o3rest/pull/3